### PR TITLE
Improve slugify that isn't working with some cases

### DIFF
--- a/lib/src/slugify.dart
+++ b/lib/src/slugify.dart
@@ -1,6 +1,6 @@
 import 'replacements.dart';
 
-final _dupeSpaceRegExp = RegExp(r'\s{2,}');
+final _dupeSpaceRegExp = RegExp(r'[-\s]+');
 final _punctuationRegExp = RegExp(r'[^\w\s-]');
 
 /// Converts [text] to a slug [String] separated by the [delimiter].
@@ -17,10 +17,10 @@ String slugify(String text, {String delimiter = '-', bool lowercase = true}) {
   replacements.forEach((k, v) => slug = slug.replaceAll(k, v));
 
   slug = slug
-      // Condense whitespaces to 1 space.
-      .replaceAll(_dupeSpaceRegExp, ' ')
       // Remove punctuation.
       .replaceAll(_punctuationRegExp, '')
+      // Condense whitespaces to 1 space.
+      .replaceAll(_dupeSpaceRegExp, ' ')
       // Replace space with the delimiter.
       .replaceAll(' ', delimiter);
 


### PR DESCRIPTION
Let's take this example string : `This IS- a C/O/MPLEX STRING - look@THAT`

According to regular slugifiers (https://slugify.online/), this string slugified should be `this-is-a-complex-string-lookthat`

However, with default slugify(), it will returns a strange string with additional dashes, thus, not very slugify-friendly.

Here the output : `this-is--a-complex-string---lookatthat`

_____________

With the codes changes, slugify() returns the expected string (I just also modified the `remplacements.dart` files to my convenience in order to prevent the '@' to become 'at', but I guess it depends on your system and your expectations)

____________
**Explanations**

- Somehow, the `_dupeSpaceRegExp` has been fixed.
- Then, the substition between the two regexes `_dupeSpaceRegExp` and `_punctuationRegExp` were to fix too; I changed the order. Now works as expected.